### PR TITLE
Fix translated text's color

### DIFF
--- a/src/main/java/me/pikamug/localelib/LocaleManager.java
+++ b/src/main/java/me/pikamug/localelib/LocaleManager.java
@@ -335,17 +335,19 @@ public class LocaleManager{
      * @return the text to replace the placeholder in the message
      */
     private String translate(String message, String key, String placeholder){
-        // If the message contains color code
+
         String replacement = "\",{\"translate\":\"" + key + "\"";
-        if(message.contains("§")){
-            // Get the text before the placeholder
-            String text = message.split(placeholder)[0];
-            // remove the §
+        // Get the text before the placeholder
+        String text = message.split(placeholder)[0];
+        // If the text before the placeholder uses any color code
+        if(text.contains("§")){
+            // Get the color code that apply on the text and remove §, so we can get the color name later
             String colorCode = ChatColor.getLastColors(text).replace("§", "");
+            // Get the color name
             String colorName = ChatColor.getByChar(colorCode).name();
 
+            // Add the color
             replacement += ", \"color\":\"" + colorName.toLowerCase() + "\"";
-
         }
 
         replacement += "},\"";


### PR DESCRIPTION
This fix #13 

`manager.sendMessage(player, ChatColor.GOLD + "This is a <item>", Material.GRASS_BLOCK, (short) 0, null);
`
![image](https://user-images.githubusercontent.com/41326473/117819119-cfbee000-b29b-11eb-80c8-778136560692.png)


`manager.sendMessage(player, ChatColor.GOLD + "This is a " + ChatColor.GREEN + "<item>", Material.GRASS_BLOCK, (short) 0, null);
`
![image](https://user-images.githubusercontent.com/41326473/117813336-89ff1900-b295-11eb-87f8-4ec0389ee7a0.png)



Also it won't affect the color after the placeholder

`manager.sendMessage(player, ChatColor.GOLD + "This is a " + ChatColor.GREEN + "<item>" + ChatColor.GOLD + ". Test", Material.GRASS_BLOCK, (short) 0, null);`

![image](https://user-images.githubusercontent.com/41326473/117814446-e44ca980-b296-11eb-946a-865285fb2483.png)


