### PR TITLE
Improved implementation of the me.pikamug.localelib.LocaleManager#toServerLocale method.

### DIFF
--- a/src/main/java/me/pikamug/localelib/LocaleKeys.java
+++ b/src/main/java/me/pikamug/localelib/LocaleKeys.java
@@ -24,8 +24,13 @@
 
 package me.pikamug.localelib;
 
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Properties;
 
 public class LocaleKeys {
     public static LinkedHashMap<String, String> getBlockKeys() {
@@ -965,5 +970,18 @@ public class LocaleKeys {
         keys.put("FISHING_HOOK", "item.fishingRod.name"); // added
         keys.put("COMPLEX_PART", "entity.EnderDragon.name"); // added
         return keys;
+    }
+
+    /**
+     * Loads all the translation entries from the en_US.lang file into a Properties object.
+     * @return A Properties object consisting of the english translations
+     * @throws IOException if an error occurred when reading from the en_US.lang file
+     */
+    public static Properties loadTranslations() throws IOException {
+        ClassLoader classLoader = JavaPlugin.class.getClassLoader();
+        InputStream inputStream = classLoader.getResourceAsStream("assets/minecraft/lang/en_US.lang");
+        Properties properties = new Properties();
+        properties.load(inputStream);
+        return properties;
     }
 }

--- a/src/main/java/me/pikamug/localelib/LocaleKeys.java
+++ b/src/main/java/me/pikamug/localelib/LocaleKeys.java
@@ -979,7 +979,7 @@ public class LocaleKeys {
      */
     public static Properties loadTranslations() throws IOException {
         ClassLoader classLoader = JavaPlugin.class.getClassLoader();
-        InputStream inputStream = classLoader.getResourceAsStream("assets/minecraft/lang/en_US.lang");
+        InputStream inputStream = classLoader.getResourceAsStream("assets/minecraft/lang/en_us.lang");
         Properties properties = new Properties();
         properties.load(inputStream);
         return properties;

--- a/src/main/java/me/pikamug/localelib/LocaleManager.java
+++ b/src/main/java/me/pikamug/localelib/LocaleManager.java
@@ -24,12 +24,10 @@
 
 package me.pikamug.localelib;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -69,6 +67,8 @@ public class LocaleManager{
     private final Map<String, String> oldLingeringPotions = LocaleKeys.getLingeringPotionKeys();
     private final Map<String, String> oldSplashPotions = LocaleKeys.getSplashPotionKeys();
     private final Map<String, String> oldEntities = LocaleKeys.getEntityKeys();
+
+    private Properties englishTranslations;
     
     public LocaleManager() {
         oldVersion = isBelow113();
@@ -95,6 +95,12 @@ public class LocaleManager{
                 localeClazz = Class.forName("net.minecraft.server.{v}.LocaleLanguage".replace("{v}", version));
             }
         } catch (final ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            englishTranslations = LocaleKeys.loadTranslations();
+        } catch (IOException e) {
             e.printStackTrace();
         }
     }
@@ -447,22 +453,16 @@ public class LocaleManager{
         }
         return lvlKeys;
     }
-    
+
     /**
      * Gets the display name of the specified material as it would appear in a Minecraft lang file.
-     * 
+     *
      * @param key the raw key for the object name
      * @return the display name of the specified key within the server locale file
      */
-    public String toServerLocale(final String key) throws IllegalAccessException, InvocationTargetException {
-        final Method trans = Arrays.stream(localeClazz.getMethods())
-                .filter(m -> m.getReturnType().equals(String.class))
-                .filter(m -> m.getParameterCount() == 1)
-                .filter(m -> m.getParameters()[0].getType().equals(String.class))
-                .collect(Collectors.toList()).get(0);
-        return (String) trans.invoke(localeClazz, key);
+    public String toServerLocale(final String key) {
+        return englishTranslations.getProperty(key);
     }
-
 
     /**
      * Translate with respect to color codes.


### PR DESCRIPTION
Previously, the method me.pikamug.localelib.LocaleManager#toServerLocale was causing an java.lang.IllegalArgumentException because of an object is not an instance of declaring class issue. (https://github.com/PikaMug/LocaleLib/issues/26)
This was because the java.lang.reflect.Method#invoke method was expecting the instance of Bukkit's LocaleLanguage class for its first parameter.
Since we won't be able to obtain this instance without NMS and creating modules for many minecraft versions.
I got the idea of looking up some code I wrote years back: Loading in the en_US.lang file stored inside each server jar.
This way we can have a copy of their translations and allow this project to expand to reach new heights such as supporting additional mappings or even other languages by saving these lang files to disk. (This is what my old source code would've done. But I had abandoned it a long time ago because I just didn't have the time on my own to manage it. But maybe this project can! So if you're interested, you may reach out to me.)

Also, since my new computer system hasn't been fully setup for Minecraft development anymore.
Please make sure this reimplementation of the me.pikamug.localelib.LocaleManager#toServerLocale works as intended.