### PR TITLE
Fix for NullPointerException while loading translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/src/main/java/me/pikamug/localelib/LocaleKeys.java
+++ b/src/main/java/me/pikamug/localelib/LocaleKeys.java
@@ -24,13 +24,19 @@
 
 package me.pikamug.localelib;
 
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.Bukkit;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Properties;
 
 public class LocaleKeys {
     public static LinkedHashMap<String, String> getBlockKeys() {
@@ -977,14 +983,71 @@ public class LocaleKeys {
      * @return Properties object consisting of the english translations
      * @throws IOException if an error occurred when reading from lang file
      */
-    public static Properties loadTranslations() throws IOException {
-        final ClassLoader classLoader = JavaPlugin.class.getClassLoader();
-        InputStream inputStream = classLoader.getResourceAsStream("assets/minecraft/lang/en_us.json");
-        if (inputStream == null) {
-            inputStream = classLoader.getResourceAsStream("assets/minecraft/lang/en_US.lang");
+    public static Map<String, String> loadTranslations() throws IOException {
+        final ClassLoader classLoader = SystemResourcesUtil.getContextClassLoader();
+        Iterator<String> matchingResources = SystemResourcesUtil.findResourcesBySearch(classLoader,"assets/minecraft/lang/", ".+(\\.json|\\.lang)");
+
+        Map<String, String> dictionary = new HashMap<>();
+        while (matchingResources.hasNext()) {
+            String resource = matchingResources.next();
+            try (InputStream inputStream = classLoader.getResourceAsStream(resource)) {
+                if (resource.endsWith(".json")) {
+                    dictionary = loadJsonFile(inputStream);
+                } else if (resource.endsWith(".lang")) {
+                    dictionary = loadLangFile(inputStream);
+                } else {
+                    dictionary = new HashMap<>();
+                }
+            }
         }
-        final Properties properties = new Properties();
-        properties.load(inputStream);
-        return properties;
+        return dictionary;
+    }
+
+    public static HashMap<String, String> loadJsonFile(InputStream inputStream) {
+        Bukkit.getLogger().info("Loading locales from json...");
+        HashMap<String, String> map = new HashMap<>();
+        try {
+            JSONParser parser = new JSONParser();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+            JSONObject json = (JSONObject) parser.parse(reader);
+
+            for (Object key : json.keySet()) {
+                String keyStr = (String) key;
+                String valueStr = (String) json.get(keyStr);
+                map.put(keyStr, valueStr);
+            }
+        } catch (IOException | ParseException e) {
+            e.printStackTrace();
+        }
+        Bukkit.getLogger().info("Finished loading locales from json, "+map.size()+" entries loaded!");
+        return map;
+    }
+
+    public static HashMap<String, String> loadLangFile(InputStream inputStream) {
+        Bukkit.getLogger().info("Loading locales from lang...");
+        HashMap<String, String> map = new HashMap<>();
+        try {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                if (line.trim().startsWith("##") || line.trim().isEmpty()) {
+                    continue;
+                }
+
+                String[] parts = line.split("=", 2);
+                if (parts.length >= 2) {
+                    String key = parts[0];
+                    String value = parts[1];
+                    map.put(key, value);
+                } else {
+                    System.out.println("ignoring line: " + line);
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        Bukkit.getLogger().info("Finished loading locales from lang, "+map.size()+" entries loaded!");
+        return map;
     }
 }

--- a/src/main/java/me/pikamug/localelib/LocaleLib.java
+++ b/src/main/java/me/pikamug/localelib/LocaleLib.java
@@ -26,159 +26,17 @@ package me.pikamug.localelib;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.io.IOException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-
 @SuppressWarnings("unused")
 public class LocaleLib extends JavaPlugin {
     private LocaleManager manager;
     
     @Override
     public void onEnable() {
-        print();
-
         manager = new LocaleManager();
     }
 
     @Override
     public void onDisable() {
-    }
-
-    public void print() {
-        listResourceTree("assets/minecraft/lang", "", 0, 3);
-        List<String> matchingPaths = searchResources("assets/minecraft/lang", ".json", 3);
-        System.out.println("Matching paths:");
-        for (String path : matchingPaths) {
-            System.out.println(path);
-        }
-    }
-
-    private void listResourceTree(String folder, String parent, int depth, int maxDepth) {
-        System.out.println(getIndentation(depth) + "+" + parent);
-        if (depth == maxDepth) return;
-        try {
-            List<String> resourcePaths = getResourcePaths(folder);
-            for (String resourcePath : resourcePaths) {
-                if (isResourceDirectory(folder, resourcePath)) {
-                    listResourceTree(folder + "/" + resourcePath, resourcePath, depth + 1, maxDepth);
-                } else {
-                    System.out.println(getIndentation(depth + 1) + "|-" + resourcePath);
-                }
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    private List<String> getResourcePaths(String folder) throws IOException {
-        List<String> resourcePaths = new ArrayList<>();
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        Enumeration<URL> urls = loader.getResources(folder);
-
-        while (urls.hasMoreElements()) {
-            URL url = urls.nextElement();
-            String protocol = url.getProtocol();
-            if (protocol.equals("jar")) {
-                String jarPath = getJarPath(url);
-                if (jarPath != null) {
-                    try (JarFile jarFile = new JarFile(URLDecoder.decode(jarPath, "UTF-8"))) {
-                        resourcePaths.addAll(getResourcePathsFromJar(jarFile, folder));
-                    }
-                }
-            } else if (protocol.equals("file")) {
-                String filePath = URLDecoder.decode(url.getPath(), "UTF-8");
-                try {
-                    resourcePaths.addAll(getResourcePathsFromFile(filePath, folder));
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
-
-        return resourcePaths;
-    }
-
-    private String getJarPath(URL jarUrl) {
-        String path = jarUrl.getPath();
-        int separatorIndex = path.indexOf('!');
-        if (separatorIndex != -1) {
-            return path.substring("file:".length(), separatorIndex);
-        }
-        return null;
-    }
-
-    private List<String> getResourcePathsFromJar(JarFile jarFile, String folder) {
-        List<String> resourcePaths = new ArrayList<>();
-
-        Enumeration<JarEntry> entries = jarFile.entries();
-        while (entries.hasMoreElements()) {
-            JarEntry entry = entries.nextElement();
-            String entryName = entry.getName();
-            if (entryName.startsWith(folder + "/")) {
-                String resourcePath = entryName.substring(folder.length() + 1);
-                if (!resourcePath.isEmpty() && !resourcePath.contains("/")) {
-                    resourcePaths.add(resourcePath);
-                }
-            }
-        }
-
-        return resourcePaths;
-    }
-
-    private List<String> getResourcePathsFromFile(String filePath, String folder) throws IOException {
-        List<String> resourcePaths = new ArrayList<>();
-        java.io.File file = new java.io.File(filePath + "/" + folder);
-        if (file.exists() && file.isDirectory()) {
-            String[] children = file.list();
-            if (children != null) {
-                for (String child : children) {
-                    if (!child.contains("/")) {
-                        resourcePaths.add(child);
-                    }
-                }
-            }
-        }
-        return resourcePaths;
-    }
-
-    private boolean isResourceDirectory(String folder, String resourcePath) {
-        return resourcePath.indexOf('/') == -1;
-    }
-
-    private String getIndentation(int depth) {
-        StringBuilder indentation = new StringBuilder();
-        for (int i = 0; i < depth; i++) {
-            indentation.append("  |");
-        }
-        return indentation.toString();
-    }
-
-    private List<String> searchResources(String folder, String searchCriteria, int maxDepth) {
-        List<String> matchingPaths = new ArrayList<>();
-        try {
-            searchResourcesRecursive(folder, "", 0, maxDepth, searchCriteria, matchingPaths);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return matchingPaths;
-    }
-
-    private void searchResourcesRecursive(String folder, String parent, int depth, int maxDepth, String searchCriteria, List<String> matchingPaths) throws IOException {
-        List<String> resourcePaths = getResourcePaths(folder);
-        for (String resourcePath : resourcePaths) {
-            if (resourcePath.endsWith(searchCriteria)) {
-                matchingPaths.add(getIndentation(depth + 1) + "- " + folder + "/" + resourcePath);
-            }
-            if (depth < maxDepth && isResourceDirectory(folder, resourcePath)) {
-                searchResourcesRecursive(folder + "/" + resourcePath, resourcePath, depth + 1, maxDepth, searchCriteria, matchingPaths);
-            }
-        }
     }
 
     public LocaleManager getLocaleManager() {

--- a/src/main/java/me/pikamug/localelib/LocaleLib.java
+++ b/src/main/java/me/pikamug/localelib/LocaleLib.java
@@ -26,17 +26,159 @@ package me.pikamug.localelib;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
 @SuppressWarnings("unused")
 public class LocaleLib extends JavaPlugin {
     private LocaleManager manager;
     
     @Override
     public void onEnable() {
+        print();
+
         manager = new LocaleManager();
     }
-    
+
     @Override
     public void onDisable() {
+    }
+
+    public void print() {
+        listResourceTree("assets/minecraft/lang", "", 0, 3);
+        List<String> matchingPaths = searchResources("assets/minecraft/lang", ".json", 3);
+        System.out.println("Matching paths:");
+        for (String path : matchingPaths) {
+            System.out.println(path);
+        }
+    }
+
+    private void listResourceTree(String folder, String parent, int depth, int maxDepth) {
+        System.out.println(getIndentation(depth) + "+" + parent);
+        if (depth == maxDepth) return;
+        try {
+            List<String> resourcePaths = getResourcePaths(folder);
+            for (String resourcePath : resourcePaths) {
+                if (isResourceDirectory(folder, resourcePath)) {
+                    listResourceTree(folder + "/" + resourcePath, resourcePath, depth + 1, maxDepth);
+                } else {
+                    System.out.println(getIndentation(depth + 1) + "|-" + resourcePath);
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private List<String> getResourcePaths(String folder) throws IOException {
+        List<String> resourcePaths = new ArrayList<>();
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        Enumeration<URL> urls = loader.getResources(folder);
+
+        while (urls.hasMoreElements()) {
+            URL url = urls.nextElement();
+            String protocol = url.getProtocol();
+            if (protocol.equals("jar")) {
+                String jarPath = getJarPath(url);
+                if (jarPath != null) {
+                    try (JarFile jarFile = new JarFile(URLDecoder.decode(jarPath, "UTF-8"))) {
+                        resourcePaths.addAll(getResourcePathsFromJar(jarFile, folder));
+                    }
+                }
+            } else if (protocol.equals("file")) {
+                String filePath = URLDecoder.decode(url.getPath(), "UTF-8");
+                try {
+                    resourcePaths.addAll(getResourcePathsFromFile(filePath, folder));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        return resourcePaths;
+    }
+
+    private String getJarPath(URL jarUrl) {
+        String path = jarUrl.getPath();
+        int separatorIndex = path.indexOf('!');
+        if (separatorIndex != -1) {
+            return path.substring("file:".length(), separatorIndex);
+        }
+        return null;
+    }
+
+    private List<String> getResourcePathsFromJar(JarFile jarFile, String folder) {
+        List<String> resourcePaths = new ArrayList<>();
+
+        Enumeration<JarEntry> entries = jarFile.entries();
+        while (entries.hasMoreElements()) {
+            JarEntry entry = entries.nextElement();
+            String entryName = entry.getName();
+            if (entryName.startsWith(folder + "/")) {
+                String resourcePath = entryName.substring(folder.length() + 1);
+                if (!resourcePath.isEmpty() && !resourcePath.contains("/")) {
+                    resourcePaths.add(resourcePath);
+                }
+            }
+        }
+
+        return resourcePaths;
+    }
+
+    private List<String> getResourcePathsFromFile(String filePath, String folder) throws IOException {
+        List<String> resourcePaths = new ArrayList<>();
+        java.io.File file = new java.io.File(filePath + "/" + folder);
+        if (file.exists() && file.isDirectory()) {
+            String[] children = file.list();
+            if (children != null) {
+                for (String child : children) {
+                    if (!child.contains("/")) {
+                        resourcePaths.add(child);
+                    }
+                }
+            }
+        }
+        return resourcePaths;
+    }
+
+    private boolean isResourceDirectory(String folder, String resourcePath) {
+        return resourcePath.indexOf('/') == -1;
+    }
+
+    private String getIndentation(int depth) {
+        StringBuilder indentation = new StringBuilder();
+        for (int i = 0; i < depth; i++) {
+            indentation.append("  |");
+        }
+        return indentation.toString();
+    }
+
+    private List<String> searchResources(String folder, String searchCriteria, int maxDepth) {
+        List<String> matchingPaths = new ArrayList<>();
+        try {
+            searchResourcesRecursive(folder, "", 0, maxDepth, searchCriteria, matchingPaths);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return matchingPaths;
+    }
+
+    private void searchResourcesRecursive(String folder, String parent, int depth, int maxDepth, String searchCriteria, List<String> matchingPaths) throws IOException {
+        List<String> resourcePaths = getResourcePaths(folder);
+        for (String resourcePath : resourcePaths) {
+            if (resourcePath.endsWith(searchCriteria)) {
+                matchingPaths.add(getIndentation(depth + 1) + "- " + folder + "/" + resourcePath);
+            }
+            if (depth < maxDepth && isResourceDirectory(folder, resourcePath)) {
+                searchResourcesRecursive(folder + "/" + resourcePath, resourcePath, depth + 1, maxDepth, searchCriteria, matchingPaths);
+            }
+        }
     }
 
     public LocaleManager getLocaleManager() {

--- a/src/main/java/me/pikamug/localelib/LocaleManager.java
+++ b/src/main/java/me/pikamug/localelib/LocaleManager.java
@@ -24,34 +24,27 @@
 
 package me.pikamug.localelib;
 
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.commons.lang.NullArgumentException;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.data.Ageable;
 import org.bukkit.enchantments.Enchantment;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Ocelot;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Rabbit;
-import org.bukkit.entity.TropicalFish;
-import org.bukkit.entity.Villager;
+import org.bukkit.entity.*;
 import org.bukkit.entity.Villager.Profession;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @SuppressWarnings("unused")
 public class LocaleManager{
@@ -68,7 +61,7 @@ public class LocaleManager{
     private final Map<String, String> oldLingeringPotions = LocaleKeys.getLingeringPotionKeys();
     private final Map<String, String> oldSplashPotions = LocaleKeys.getSplashPotionKeys();
     private final Map<String, String> oldEntities = LocaleKeys.getEntityKeys();
-    private Properties englishTranslations;
+    private Map<String, String> englishTranslations;
     
     public LocaleManager() {
         oldVersion = isBelow113();
@@ -97,6 +90,9 @@ public class LocaleManager{
         }
         try {
             englishTranslations = LocaleKeys.loadTranslations();
+            if (englishTranslations.isEmpty()) {
+                Bukkit.getLogger().warning("The English locale couldn't be found or loaded!");
+            }
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -459,8 +455,8 @@ public class LocaleManager{
      * @param key the raw key for the object name
      * @return the display name of the specified key within the server locale file
      */
-    public String toServerLocale(final String key) throws IllegalAccessException, InvocationTargetException {
-        return englishTranslations.getProperty(key);
+    public String toServerLocale(final String key) {
+        return englishTranslations.getOrDefault(key, "<none>");
     }
 
 

--- a/src/main/java/me/pikamug/localelib/SystemResourcesUtil.java
+++ b/src/main/java/me/pikamug/localelib/SystemResourcesUtil.java
@@ -1,0 +1,80 @@
+package me.pikamug.localelib;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.*;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SystemResourcesUtil {
+
+    /**
+     * Returns the context ClassLoader for this thread. The context ClassLoader may be set by the creator of the thread for use by code running in this thread when loading classes and resources. If not {@link Thread#setContextClassLoader(ClassLoader) set}, the default is to inherit the context class loader from the parent thread.
+     * The context ClassLoader of the primordial thread is typically set to the class loader used to load the application.
+     * @return The context class loader of the current thread.
+     */
+    public static ClassLoader getContextClassLoader() {
+        return Thread.currentThread().getContextClassLoader();
+    }
+
+    /**
+     * Searches for all resource paths found inside the baseFolder on the loader using the searchCriteria.
+     * @param loader The class loader to search on
+     * @param baseFolder The resource folder to search in
+     * @param searchCriteria The search criteria to apply
+     * @return An iterator that iterates over all matching resources
+     * @throws IOException if an I/O error has occurred
+     */
+    public static Iterator<String> findResourcesBySearch(ClassLoader loader, String baseFolder, String searchCriteria) throws IOException {
+        Pattern pattern = Pattern.compile(searchCriteria);
+        Enumeration<URL> urls = loader.getResources(baseFolder);
+
+        List<String> matchingResources = new ArrayList<>();
+
+        while (urls.hasMoreElements()) {
+            URL url = urls.nextElement();
+            String protocol = url.getProtocol();
+            if (protocol.equals("jar")) {
+                String jarPath = getJarPath(url);
+                if (jarPath != null) {
+                    try (JarFile jarFile = new JarFile(URLDecoder.decode(jarPath, "UTF-8"))) {
+                        matchingResources.addAll(getMatchingResourcesFromJar(jarFile, pattern, baseFolder));
+                    }
+                }
+            }
+        }
+
+        return matchingResources.iterator();
+    }
+
+    private static String getJarPath(URL jarUrl) {
+        String path = jarUrl.getPath();
+        int separatorIndex = path.indexOf('!');
+        if (separatorIndex != -1) {
+            return path.substring("file:".length(), separatorIndex);
+        }
+        return null;
+    }
+
+    private static List<String> getMatchingResourcesFromJar(JarFile jarFile, Pattern pattern, String baseFolder) {
+        List<String> matchingResources = new ArrayList<>();
+
+        Enumeration<JarEntry> entries = jarFile.entries();
+        while (entries.hasMoreElements()) {
+            JarEntry entry = entries.nextElement();
+            String entryName = entry.getName();
+            if (entryName.startsWith(baseFolder)) {
+                String remainingPath = entryName.substring(baseFolder.length());
+                Matcher matcher = pattern.matcher(remainingPath);
+                if (matcher.find()) {
+                    matchingResources.add(entryName);
+                }
+            }
+        }
+
+        return matchingResources;
+    }
+}


### PR DESCRIPTION
**Problem**
Issue #28 reported a `NullPointerException` that occurred while loading English translations, specifically when trying to access `assets/minecraft/lang/en_us.json`. This error was observed in both 1.12.2 and 1.16.5 versions using Java 8, and was associated with the `LocaleManager#toServerLocale` method.

**Solution**
This PR addresses the problem by enhancing the scanning process for the English language files. It now properly scans for either `en_us.json`, `en_us.lang`, `en_US.json`, or `en_US.lang` files and reads the appropriate JSON or lang file type into a Java HashMap. 

Furthermore, the solution is future-proofed with respect to the naming of these files. This should ensure that the correct locale files are found and loaded, regardless of minor variations in the file name or format.

**Testing**
To ensure that the fix was effective, a series of tests were conducted across multiple versions of both Spigot and Paper. The tests included querying for various entities, materials, enchantments, and levels, and then logging the resulting translations. The test results showed successful loading of translations across all tested versions, confirming that the fix has addressed the issue effectively.

Here's a summary of the tests:
```

==========================================================================================================================================
The Applied Test Code
------------------------------------------------------------------------------------------------------------------------------------------
List<String> testKeys = new ArrayList<>();
testKeys.add(manager.queryMaterial(Material.SLIME_BLOCK));
testKeys.add(manager.queryEntityType(EntityType.COW, null));

Map<Enchantment, Integer> enchantments = new HashMap<>();
enchantments.put(Enchantment.DURABILITY, 3);
testKeys.add(manager.queryEnchantments(enchantments).get(Enchantment.DURABILITY));
testKeys.add(manager.queryLevels(enchantments).get(3));

Bukkit.getLogger().info("Translation List:");
for (String testKey : testKeys) {
    String translation = manager.toServerLocale(testKey);
    Bukkit.getLogger().log("<none>".equals(translation)? Level.WARNING : Level.INFO, String.format("%s: %s", testKey, translation));
}
Bukkit.getLogger().info("----------------------------------------");

==========================================================================================================================================

Tested versions:
 - 1.8.8 (spigot & paper)
 - 1.12.2 (paper)
 - 1.16.5 (spigot & paper)
 - 1.19.4 (spigot & paper)
 
==========================================================================================================================================
Test Result: 1.19.4 (Paper)
------------------------------------------------------------------------------------------------------------------------------------------
[LocaleLib] Enabling LocaleLib v3.4
Loading locales from json...
Finished loading locales from json, 6063 entries loaded!
Translation List:
block.minecraft.slime_block: Slime Block
entity.minecraft.cow: Cow
enchantment.minecraft.unbreaking: Unbreaking
enchantment.level.3: III
----------------------------------------
==========================================================================================================================================
Test Result: 1.19.4 (Spigot)
------------------------------------------------------------------------------------------------------------------------------------------
[LocaleLib] Enabling LocaleLib v3.4
Loading locales from json...
Finished loading locales from json, 6063 entries loaded!
Translation List:
block.minecraft.slime_block: Slime Block
entity.minecraft.cow: Cow
enchantment.minecraft.unbreaking: Unbreaking
enchantment.level.3: III
----------------------------------------
==========================================================================================================================================
Test Result: 1.16.5 (Paper)
------------------------------------------------------------------------------------------------------------------------------------------
[LocaleLib] Enabling LocaleLib v3.4
Loading locales from json...
Finished loading locales from json, 4812 entries loaded!
Translation List:
block.minecraft.slime_block: Slime Block
entity.minecraft.cow: Cow
enchantment.minecraft.unbreaking: Unbreaking
enchantment.level.3: III
----------------------------------------
==========================================================================================================================================
Test Result: 1.16.5 (Spigot)
------------------------------------------------------------------------------------------------------------------------------------------
[LocaleLib] Enabling LocaleLib v3.4
Loading locales from json...
Finished loading locales from json, 4812 entries loaded!
Translation List:
block.minecraft.slime_block: Slime Block
entity.minecraft.cow: Cow
enchantment.minecraft.unbreaking: Unbreaking
enchantment.level.3: III
----------------------------------------
==========================================================================================================================================
Test Result: 1.12.2 (Paper)
------------------------------------------------------------------------------------------------------------------------------------------
[LocaleLib] Enabling LocaleLib v3.4
Loading locales from lang...
Finished loading locales from lang, 3303 entries loaded!
Translation List:
tile.slime.name: Slime Block
entity.Cow.name: Cow
enchantment.durability: Unbreaking
enchantment.level.3: III
----------------------------------------
==========================================================================================================================================
Test Result: 1.8.8 (Paper) (Success)
------------------------------------------------------------------------------------------------------------------------------------------
[LocaleLib] Enabling LocaleLib v3.4
Loading locales from lang...
Finished loading locales from lang, 2552 entries loaded!
Translation List:
tile.slime.name: Slime Block
entity.Cow.name: Cow
enchantment.durability: Unbreaking
enchantment.level.3: III
----------------------------------------
==========================================================================================================================================
Test Result: 1.8.8 (Spigot)
------------------------------------------------------------------------------------------------------------------------------------------
[LocaleLib] Enabling LocaleLib v3.4
Loading locales from lang...
Finished loading locales from lang, 2552 entries loaded!
Translation List:
tile.slime.name: Slime Block
entity.Cow.name: Cow
enchantment.durability: Unbreaking
enchantment.level.3: III
----------------------------------------
==========================================================================================================================================

```

Please review the changes made in this PR and provide any feedback or suggestions.