### PR TITLE
Remove exception logging in queryMaterial

### DIFF
--- a/src/main/java/me/pikamug/localelib/LocaleManager.java
+++ b/src/main/java/me/pikamug/localelib/LocaleManager.java
@@ -442,8 +442,7 @@ public class LocaleManager{
                                 .replace("instant_heal", "healing").replace("instant_damage", "harming");
                     }
                 } catch (final Exception ex) {
-                    ex.printStackTrace();
-                    throw new IllegalArgumentException("[LocaleLib] Unable to query Material: " + material.name());
+                    throw new IllegalArgumentException("[LocaleLib] Unable to query Material: " + material.name(), ex);
                 }
             }
         }


### PR DESCRIPTION
I removed an unnecessary `Throwable#printStackTrace` call and included the caught exception with the raised exception.

I had an issue with it polluting my console window because of my library usage (I have other behavior for null values).

```
[02:23:24 WARN]: java.lang.IllegalArgumentException: WATER material could not be queried!
```