### PR TITLE
fix: ignore extra json file that break parsing

### DIFF
--- a/src/main/java/me/pikamug/localelib/LocaleKeys.java
+++ b/src/main/java/me/pikamug/localelib/LocaleKeys.java
@@ -1019,6 +1019,13 @@ public class LocaleKeys {
         Map<String, String> dictionary = new HashMap<>();
         while (matchingResources.hasNext()) {
             String resource = matchingResources.next();
+
+            if (resource.endsWith("_all.json")
+                || resource.endsWith("_list.json")
+                || resource.endsWith("deprecated.json")) {
+                continue;
+            }
+
             try (InputStream inputStream = classLoader.getResourceAsStream(resource)) {
                 if (resource.endsWith(".json")) {
                     dictionary = loadJsonFile(inputStream);


### PR DESCRIPTION
In 1.21.3 there is a deprecated.json in the lang folder that breaks parsing