### PR TITLE
fix: report unsupported server version at startup instead of misleading per-message errors

### DIFF
--- a/src/main/java/me/pikamug/localelib/LocaleManager.java
+++ b/src/main/java/me/pikamug/localelib/LocaleManager.java
@@ -92,7 +92,12 @@ public class LocaleManager{
                 }
             }
         } catch (final ClassNotFoundException e) {
-            e.printStackTrace();
+            Bukkit.getLogger().severe("[LocaleLib] Unable to resolve NMS/CraftBukkit classes for this server "
+                    + "version: " + e.getMessage());
+        }
+        if (!oldVersion && (craftMagicNumbers == null || itemClazz == null)) {
+            Bukkit.getLogger().severe("[LocaleLib] This server version does not appear to be supported. "
+                    + "Material name translation will not work; entity and enchantment translation are unaffected.");
         }
         try {
             englishTranslations = LocaleKeys.loadTranslations();
@@ -446,6 +451,10 @@ public class LocaleManager{
             if (material.isBlock() && material.createBlockData() instanceof Ageable) {
                 matKey = "block.minecraft." + material.name().toLowerCase();
             } else {
+                if (craftMagicNumbers == null || itemClazz == null) {
+                    throw new IllegalArgumentException("[LocaleLib] Cannot query material '" + material.name()
+                            + "': NMS/CraftBukkit classes were not resolved for this server version at startup.");
+                }
                 try {
                     final Method itemMethod = craftMagicNumbers.getDeclaredMethod("getItem", material.getClass());
                     itemMethod.setAccessible(true);

--- a/src/main/java/me/pikamug/localelib/LocaleManager.java
+++ b/src/main/java/me/pikamug/localelib/LocaleManager.java
@@ -76,6 +76,7 @@ public class LocaleManager{
             isPost1dot18 = true;
         }
         final String packageName = Bukkit.getServer().getClass().getPackage().getName();
+        final String bukkitVersion = Bukkit.getBukkitVersion();
         try {
             if (packageName.equals("org.bukkit.craftbukkit")) {
                 // Bukkit version is 1.20.5+
@@ -93,11 +94,12 @@ public class LocaleManager{
             }
         } catch (final ClassNotFoundException e) {
             Bukkit.getLogger().severe("[LocaleLib] Unable to resolve NMS/CraftBukkit classes for this server "
-                    + "version: " + e.getMessage());
+                    + "version (" + bukkitVersion + "): " + e.getMessage());
         }
         if (!oldVersion && (craftMagicNumbers == null || itemClazz == null)) {
-            Bukkit.getLogger().severe("[LocaleLib] This server version does not appear to be supported. "
-                    + "Material name translation will not work; entity and enchantment translation are unaffected.");
+            Bukkit.getLogger().severe("[LocaleLib] This server version (" + bukkitVersion + ") does not appear to "
+                    + "be supported. Material name translation will not work; entity and enchantment translation "
+                    + "are unaffected.");
         }
         try {
             englishTranslations = LocaleKeys.loadTranslations();
@@ -453,7 +455,8 @@ public class LocaleManager{
             } else {
                 if (craftMagicNumbers == null || itemClazz == null) {
                     throw new IllegalArgumentException("[LocaleLib] Cannot query material '" + material.name()
-                            + "': NMS/CraftBukkit classes were not resolved for this server version at startup.");
+                            + "': NMS/CraftBukkit classes were not resolved for this server version ("
+                            + Bukkit.getBukkitVersion() + ") at startup.");
                 }
                 try {
                     final Method itemMethod = craftMagicNumbers.getDeclaredMethod("getItem", material.getClass());


### PR DESCRIPTION
## Problem

If the constructor's NMS/CraftBukkit class resolution fails (e.g. an
unsupported or unrecognized server version), the failure was only ever
printed to console via `e.printStackTrace()` and then silently dropped.
`craftMagicNumbers`/`itemClazz` are left null, but `queryMaterial`
dereferences them directly with no null check.

That dereference is caught by `queryMaterial`'s existing catch-all, so it
doesn't crash — but it gets wrapped into a generic
"[LocaleLib] Unable to query Material: X" error, repeated every single
time a player triggers a translated message, with nothing pointing at the
actual cause (the server version isn't supported).

## Fix

- Replaced the swallowed `e.printStackTrace()` in the constructor with
  `Bukkit.getLogger().severe(...)`, and added one clear severe log line
  at startup when NMS class resolution fails on a modern (1.13+) server,
  so the real problem is visible immediately instead of only in a console
  stack trace.
- Added an explicit null check in `queryMaterial` before attempting the
  reflection call, throwing a specific message ("NMS/CraftBukkit classes
  were not resolved for this server version at startup") instead of
  falling into the generic per-material catch-all.

## Testing

Reviewed manually; behavior for supported server versions is unchanged.
No automated tests included with this PR.