### PR TITLE
test: add JUnit tests for LocaleParser and LocaleKeys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
             <version>1.13.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/src/test/java/me/pikamug/localelib/LocaleKeysTest.java
+++ b/src/test/java/me/pikamug/localelib/LocaleKeysTest.java
@@ -1,0 +1,77 @@
+package me.pikamug.localelib;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Sanity tests for the hardcoded legacy translation key tables in {@link LocaleKeys}. These only
+ * exercise the plain map-building getters (no Bukkit API calls), so they run without a live
+ * server or any mocking. {@link LocaleKeys#loadTranslations()} and its helpers are not covered
+ * here since they call into the Bukkit API.
+ */
+public class LocaleKeysTest {
+
+    @Test
+    public void getBlockKeys_hasNoNullEntries() {
+        assertNoNullEntries(LocaleKeys.getBlockKeys());
+    }
+
+    @Test
+    public void getBlockKeys_containsKnownEntries() {
+        Map<String, String> blocks = LocaleKeys.getBlockKeys();
+        assertEquals("tile.air.name", blocks.get("AIR"));
+        assertEquals("tile.dirt.name", blocks.get("DIRT"));
+        assertEquals("tile.chest.name", blocks.get("CHEST"));
+    }
+
+    @Test
+    public void getItemKeys_hasNoNullEntries() {
+        assertNoNullEntries(LocaleKeys.getItemKeys());
+    }
+
+    @Test
+    public void getItemKeys_containsKnownEntries() {
+        Map<String, String> items = LocaleKeys.getItemKeys();
+        assertEquals("item.apple.name", items.get("APPLE"));
+        assertEquals("item.diamond.name", items.get("DIAMOND"));
+        assertEquals("item.bow.name", items.get("BOW"));
+    }
+
+    @Test
+    public void getEntityKeys_hasNoNullEntries() {
+        assertNoNullEntries(LocaleKeys.getEntityKeys());
+    }
+
+    @Test
+    public void getEntityKeys_containsKnownEntries() {
+        Map<String, String> entities = LocaleKeys.getEntityKeys();
+        assertEquals("entity.Creeper.name", entities.get("CREEPER"));
+        assertEquals("entity.Zombie.name", entities.get("ZOMBIE"));
+    }
+
+    @Test
+    public void getPotionKeys_hasNoNullEntries() {
+        assertNoNullEntries(LocaleKeys.getPotionKeys());
+    }
+
+    @Test
+    public void getPotionKeys_containsKnownEntries() {
+        Map<String, String> potions = LocaleKeys.getPotionKeys();
+        assertEquals("potion.effect.water", potions.get("WATER"));
+        assertEquals("potion.effect.regeneration", potions.get("REGEN"));
+    }
+
+    private static void assertNoNullEntries(Map<String, String> map) {
+        assertNotNull("map should not be null", map);
+        assertFalse("map should not be empty", map.isEmpty());
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            assertNotNull("null key found in map", entry.getKey());
+            assertNotNull("null value for key: " + entry.getKey(), entry.getValue());
+        }
+    }
+}

--- a/src/test/java/me/pikamug/localelib/LocaleParserTest.java
+++ b/src/test/java/me/pikamug/localelib/LocaleParserTest.java
@@ -1,0 +1,107 @@
+package me.pikamug.localelib;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link LocaleParser}. This class has no Bukkit API dependency, so these tests
+ * run as plain JUnit with no live server and no mocking involved.
+ */
+public class LocaleParserTest {
+
+    /** The Minecraft "section sign" formatting character, written out to keep test strings readable. */
+    private static final char S = '§';
+
+    private final LocaleParser parser = new LocaleParser();
+
+    // ---- convertFormattingTokens ----
+
+    @Test
+    public void convertFormattingTokens_passesPlainTextThrough() {
+        String input = "Hello &aWorld, &lbold codes and plain text are left untouched.";
+        assertEquals(input, parser.convertFormattingTokens(input));
+    }
+
+    @Test
+    public void convertFormattingTokens_convertsPercentHexToken() {
+        String result = parser.convertFormattingTokens("%#1A2b3C%");
+        String expected = "" + S + "x" + S + "1" + S + "A" + S + "2" + S + "b" + S + "3" + S + "C";
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void convertFormattingTokens_convertsAmpersandHexToken() {
+        String result = parser.convertFormattingTokens("&#00ff99");
+        String expected = "" + S + "x" + S + "0" + S + "0" + S + "f" + S + "f" + S + "9" + S + "9";
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void convertFormattingTokens_convertsMultipleMixedTokens() {
+        String result = parser.convertFormattingTokens("%#FF0000%mid&#00FF00tail");
+        String percentPart = "" + S + "x" + S + "F" + S + "F" + S + "0" + S + "0" + S + "0" + S + "0";
+        String ampPart = "" + S + "x" + S + "0" + S + "0" + S + "F" + S + "F" + S + "0" + S + "0";
+        String expected = percentPart + "mid" + ampPart + "tail";
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void convertFormattingTokens_ignoresInvalidHexLength() {
+        // Only 5 hex digits before the closing '%' - should not match and should be left as-is.
+        String input = "%#12345% is too short to match";
+        assertEquals(input, parser.convertFormattingTokens(input));
+    }
+
+    // ---- buildTellrawJson ----
+
+    @Test
+    public void buildTellrawJson_plainTextNoFormatting() {
+        String json = parser.buildTellrawJson("Hello world", null, null);
+        assertEquals("[{\"text\":\"Hello world\"}]", json);
+    }
+
+    @Test
+    public void buildTellrawJson_standardColorCode() {
+        String json = parser.buildTellrawJson("" + S + "cHello", null, null);
+        assertEquals("[{\"text\":\"Hello\",\"color\":\"red\"}]", json);
+    }
+
+    @Test
+    public void buildTellrawJson_boldThenReset() {
+        String json = parser.buildTellrawJson("" + S + "lBold" + S + "rNormal", null, null);
+        assertEquals("[{\"text\":\"Bold\",\"bold\":true},{\"text\":\"Normal\"}]", json);
+    }
+
+    @Test
+    public void buildTellrawJson_placeholderSubstitution() {
+        String json = parser.buildTellrawJson("Hello <item>!",
+                new String[]{"<item>"}, new String[]{"item.diamond.name"});
+        assertEquals("[{\"text\":\"Hello \"},{\"translate\":\"item.diamond.name\"},{\"text\":\"!\"}]", json);
+    }
+
+    @Test
+    public void buildTellrawJson_escapesQuoteCharacters() {
+        String input = "He said " + "\"" + "hi" + "\"";
+        String json = parser.buildTellrawJson(input, null, null);
+        String expectedText = "He said " + "\\\"" + "hi" + "\\\"";
+        assertEquals("[{\"text\":\"" + expectedText + "\"}]", json);
+    }
+
+    @Test
+    public void buildTellrawJson_escapesBackslashAndControlCharacters() {
+        String input = "back" + "\\" + "slash" + "\t" + "tab" + "\n" + "line" + "\r" + "return";
+        String json = parser.buildTellrawJson(input, null, null);
+        String expectedText = "back" + "\\\\" + "slash" + "\\t" + "tab" + "\\n" + "line" + "\\r" + "return";
+        assertEquals("[{\"text\":\"" + expectedText + "\"}]", json);
+    }
+
+    @Test
+    public void buildTellrawJson_hexColorSequenceFromConvertedTokens() {
+        // Exercises convertFormattingTokens and buildTellrawJson together, matching real usage
+        // in LocaleManager: a message is converted first, then turned into tellraw JSON.
+        String converted = parser.convertFormattingTokens("Hello %#FF0000%World");
+        String json = parser.buildTellrawJson(converted, null, null);
+        assertEquals("[{\"text\":\"Hello \"},{\"text\":\"World\",\"color\":\"#ff0000\"}]", json);
+    }
+}


### PR DESCRIPTION
## Problem

There's no automated test coverage in this project, and no test
dependency in the pom. `LocaleParser` (hex/color token parsing, tellraw
JSON building) is pure logic with no Bukkit dependency, which makes it
straightforward to test directly.

## Change

- Added `junit:junit:4.13.2` as a `test`-scoped dependency.
- Added `LocaleParserTest`, covering `convertFormattingTokens`
  (`%#RRGGBB%` and `&#RRGGBB` hex tokens, mixed tokens, invalid-length
  tokens, plain text passthrough) and `buildTellrawJson` (standard color
  codes, bold/reset, placeholder substitution, hex color sequences, and
  escaping of quotes/backslashes/control characters), plus one test that
  chains both methods together the way `LocaleManager` actually uses
  them.
- Added `LocaleKeysTest`, with sanity checks (no null keys/values, a few
  known entries) for the block/item/entity/potion key tables. This
  intentionally does not cover `LocaleKeys#loadTranslations()` or its
  helpers, since those call into the Bukkit API.

No production code changes.

## How to run these tests manually

From the project root:

    mvn test

A successful run ends with something like:

    Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
    BUILD SUCCESS

To run just one of the two test classes:

    mvn test -Dtest=LocaleParserTest
    mvn test -Dtest=LocaleKeysTest