### PR TITLE
ci: add GitHub Actions workflow to run mvn test on push and PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: maven
+
+      - name: Build and test with Maven
+        run: mvn -B test


### PR DESCRIPTION
## Problem

There's no in-repo CI. The README's build badge points to an external
Jenkins job, so build breaks aren't caught automatically on PRs here.

## Change

Added `.github/workflows/build.yml`: checks out the repo, sets up JDK 8
(matching this project's `<source>`/`<target>` in the pom), and runs
`mvn -B test`. Triggers on pushes and pull requests targeting either
`master` or `main`, to cover both without needing to know in advance
which one is the default branch. Maven dependencies are cached between
runs via `actions/setup-java`'s built-in cache support.

No production code changes.

## Repo settings — what's needed vs. optional

**Nothing needs to change for this to start working.** GitHub Actions is
enabled by default for public repos, this workflow needs no secrets or
special permissions, and it runs the same way for PRs from forks (with
the default read-only `GITHUB_TOKEN`) as it does for pushes.

**Optional:** if you want a failing build to actually block merging
(rather than just show a red X), that's a separate opt-in step: Settings
→ Branches → add/edit a protection rule for your default branch → enable
"Require status checks to pass before merging" → select the "Build"
check (it'll show up in that list after this workflow has run at least
once). Not required — just flagging it since it's the one setting this
PR doesn't turn on by itself.

## How to verify

Once merged (or from this PR itself), the "Build" check should appear
under the Checks tab and in the PR's status checks, running the same
`mvn test` that passed locally in #40.

## Note: the "Build" check isn't showing up on this PR

Heads up — the Checks tab on this PR shows 0, and the repo's Actions tab
has no run history at all (not even a pending/waiting one). The workflow
file itself runs fine locally (mvn test passes, see #40).

@PikaMug could you check Settings → Actions → General → "Actions
permissions" for this repo? A fully empty run history (nothing queued,
nothing pending approval) is consistent with Actions being disabled or
restricted here. If Actions are already enabled, the other possibility is
a pending "Approve and run workflows" prompt that only shows up on your
side for first-time contributor PRs from forks — worth a look either way.