### PR TITLE
refactor: send chat via real components instead of tellraw JSON

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,27 @@
             <version>1.13.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Always present at runtime: spigot-api itself depends on bungeecord-chat, and every
+             Spigot/Paper/Purpur server since 1.13 bundles it. Declared explicitly here (rather than
+             relying on transitive/provided propagation from spigot-api) since it's now used directly
+             for building real chat components instead of hand-built tellraw JSON strings. -->
+        <dependency>
+            <groupId>net.md-5</groupId>
+            <artifactId>bungeecord-chat</artifactId>
+            <version>1.21-R0.4</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Compile-only: only present at runtime on Paper and Paper forks (Purpur, etc.), never on
+             plain Spigot/CraftBukkit. Used solely inside AdventureComponentMessenger, which is only
+             ever loaded via reflection after confirming Adventure's presence at startup - see that
+             class for details on why this is safe on servers without it. Version matches what current
+             Paper builds bundle (paper-api build.gradle.kts pins adventureVersion = 4.26.1). -->
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-api</artifactId>
+            <version>4.26.1</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/src/main/java/me/pikamug/localelib/AdventureComponentMessenger.java
+++ b/src/main/java/me/pikamug/localelib/AdventureComponentMessenger.java
@@ -1,0 +1,75 @@
+package me.pikamug.localelib;
+
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+/**
+ * Sends messages using the real Adventure API ({@code net.kyori.adventure}), available on Paper
+ * and its forks (Purpur, etc.) but not on plain Spigot/CraftBukkit.
+ *
+ * <p><b>Loading safety:</b> this class must never be referenced by type - import, field, method
+ * signature, {@code instanceof}, or {@code new} - from {@link LocaleManager} or any other class
+ * that is always loaded. {@code LocaleManager} only ever loads it via
+ * {@code Class.forName("me.pikamug.localelib.AdventureComponentMessenger")}, and only after first
+ * confirming, via a separate check that references no Adventure types at all, that the running
+ * server's {@code Player} class actually implements {@code net.kyori.adventure.audience.Audience}.
+ * That ordering is what keeps every other server safe: the JVM never attempts to resolve this
+ * class - and transitively, the Adventure classes it references - unless that check has already
+ * passed. Do not add a direct reference to this class anywhere else in the codebase.
+ */
+final class AdventureComponentMessenger implements ComponentMessenger {
+
+    @Override
+    public void send(final Player player, final List<MessageSegment> segments) {
+        Component message = Component.empty();
+        for (final MessageSegment segment : segments) {
+            message = message.append(toComponent(segment));
+        }
+        ((Audience) player).sendMessage(message);
+    }
+
+    private Component toComponent(final MessageSegment segment) {
+        Component component = segment.isTranslatable()
+                ? Component.translatable(segment.getContent())
+                : Component.text(segment.getContent());
+        if (segment.getColor() != null) {
+            final TextColor color = resolveColor(segment.getColor());
+            if (color != null) {
+                component = component.color(color);
+            }
+        }
+        if (segment.isBold()) {
+            component = component.decorate(TextDecoration.BOLD);
+        }
+        if (segment.isItalic()) {
+            component = component.decorate(TextDecoration.ITALIC);
+        }
+        if (segment.isUnderline()) {
+            component = component.decorate(TextDecoration.UNDERLINED);
+        }
+        if (segment.isStrikethrough()) {
+            component = component.decorate(TextDecoration.STRIKETHROUGH);
+        }
+        if (segment.isObfuscated()) {
+            component = component.decorate(TextDecoration.OBFUSCATED);
+        }
+        return component;
+    }
+
+    /**
+     * Resolves either a hex string (e.g. {@code "#ff0000"}) or a legacy Minecraft color name
+     * (e.g. {@code "red"}) - the two formats {@link MessageSegment#getColor()} ever produces.
+     */
+    private static TextColor resolveColor(final String color) {
+        if (color.startsWith("#")) {
+            return TextColor.fromHexString(color);
+        }
+        return NamedTextColor.NAMES.value(color);
+    }
+}

--- a/src/main/java/me/pikamug/localelib/BungeeComponentMessenger.java
+++ b/src/main/java/me/pikamug/localelib/BungeeComponentMessenger.java
@@ -1,0 +1,55 @@
+package me.pikamug.localelib;
+
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.chat.TranslatableComponent;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+/**
+ * Sends messages using the BungeeCord Chat API ({@code net.md_5.bungee.api.chat}), which every
+ * Spigot/Paper/Purpur server has bundled since 1.13 - {@code spigot-api} itself depends on it, so
+ * this is always safe to use. This is the universal implementation used whenever
+ * {@link AdventureComponentMessenger} isn't available (i.e. on everything except Paper and its
+ * forks).
+ */
+final class BungeeComponentMessenger implements ComponentMessenger {
+
+    @Override
+    public void send(final Player player, final List<MessageSegment> segments) {
+        final BaseComponent[] components = new BaseComponent[segments.size()];
+        for (int i = 0; i < segments.size(); i++) {
+            components[i] = toComponent(segments.get(i));
+        }
+        player.spigot().sendMessage(components);
+    }
+
+    private BaseComponent toComponent(final MessageSegment segment) {
+        final BaseComponent component = segment.isTranslatable()
+                ? new TranslatableComponent(segment.getContent())
+                : new TextComponent(segment.getContent());
+        if (segment.getColor() != null) {
+            // Accepts both legacy color names (e.g. "red") and hex strings (e.g. "#ff0000") -
+            // exactly the two formats MessageSegment#getColor() ever produces.
+            component.setColor(ChatColor.of(segment.getColor()));
+        }
+        if (segment.isBold()) {
+            component.setBold(true);
+        }
+        if (segment.isItalic()) {
+            component.setItalic(true);
+        }
+        if (segment.isUnderline()) {
+            component.setUnderlined(true);
+        }
+        if (segment.isStrikethrough()) {
+            component.setStrikethrough(true);
+        }
+        if (segment.isObfuscated()) {
+            component.setObfuscated(true);
+        }
+        return component;
+    }
+}

--- a/src/main/java/me/pikamug/localelib/ComponentMessenger.java
+++ b/src/main/java/me/pikamug/localelib/ComponentMessenger.java
@@ -1,0 +1,19 @@
+package me.pikamug.localelib;
+
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+/**
+ * Sends a parsed, formatted message to a player as a real chat component, instead of building a
+ * raw JSON string and dispatching it through a console "tellraw" command. Package-private:
+ * internal implementation detail, not part of the library's public API.
+ *
+ * <p>Implementations must be safe to construct on every supported server. The one implementation
+ * that isn't ({@link AdventureComponentMessenger}, which depends on a library only present on
+ * Paper and its forks) is never referenced by type from here or from {@link LocaleManager} - see
+ * that class's Javadoc for how it's loaded safely.
+ */
+interface ComponentMessenger {
+    void send(Player player, List<MessageSegment> segments);
+}

--- a/src/main/java/me/pikamug/localelib/LocaleManager.java
+++ b/src/main/java/me/pikamug/localelib/LocaleManager.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings("unused")
@@ -60,6 +61,7 @@ public class LocaleManager{
     private final Map<String, String> oldEntities = LocaleKeys.getEntityKeys();
     private Map<String, String> englishTranslations;
     private final LocaleParser localeParser = new LocaleParser();
+    private final ComponentMessenger messenger = createMessenger();
 
     public LocaleManager() {
         oldVersion = isBelow113();
@@ -102,6 +104,51 @@ public class LocaleManager{
     }
 
     /**
+     * Chooses how to send formatted chat components: real Adventure
+     * ({@link AdventureComponentMessenger}) if this server supports it (Paper and its forks),
+     * otherwise the BungeeCord Chat API ({@link BungeeComponentMessenger}), which every
+     * Spigot-API-based server has bundled since 1.13.
+     *
+     * <p>{@code AdventureComponentMessenger} is loaded only via reflection, and only after
+     * {@link #isAdventureSupported()} - which references no Adventure type itself - has confirmed
+     * support. This ordering means the JVM never attempts to resolve Adventure's classes on a
+     * server that doesn't have them. Do not change this to a direct
+     * {@code new AdventureComponentMessenger()}; that would defeat the whole point.
+     *
+     * @return the messenger to use for the lifetime of this LocaleManager instance
+     */
+    private static ComponentMessenger createMessenger() {
+        if (isAdventureSupported()) {
+            try {
+                return (ComponentMessenger) Class.forName("me.pikamug.localelib.AdventureComponentMessenger")
+                        .getDeclaredConstructor().newInstance();
+            } catch (final ReflectiveOperationException | LinkageError e) {
+                Bukkit.getLogger().warning("[LocaleLib] Adventure appears to be supported but the Adventure "
+                        + "messenger could not be loaded; falling back to BungeeCord chat components. " + e);
+            }
+        }
+        return new BungeeComponentMessenger();
+    }
+
+    /**
+     * Checks, without referencing any Adventure type directly, whether the running server's
+     * {@code Player} class implements {@code net.kyori.adventure.audience.Audience}. True on
+     * Paper and its forks; false on plain Spigot/CraftBukkit, where Adventure isn't on the
+     * classpath at all.
+     *
+     * @return true if this server's Player implementation supports Adventure
+     */
+    private static boolean isAdventureSupported() {
+        try {
+            final Class<?> audienceClass = Class.forName("net.kyori.adventure.audience.Audience");
+            final Class<?> playerClass = Class.forName("org.bukkit.entity.Player");
+            return audienceClass.isAssignableFrom(playerClass);
+        } catch (final ClassNotFoundException | LinkageError e) {
+            return false;
+        }
+    }
+
+    /**
      * Send message with item name translated to the client's locale.
      * ItemStack is required. This method supports 1.8 potions.<p>
      *
@@ -129,9 +176,9 @@ public class LocaleManager{
             if (potion.getType().getEffectType() != null) {
                 potionName = oldPotions1dot8.get(potion.getType().getEffectType().getName());
             }
-            final String json = localeParser.buildTellrawJson(msg, new String[]{"<prefix>", "<item>"},
+            final List<MessageSegment> segments = localeParser.parseSegments(msg, new String[]{"<prefix>", "<item>"},
                     new String[]{prefixKey, potionName});
-            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + formatName(player) + " " + json);
+            messenger.send(player, segments);
             return true;
         }
         return sendMessage(player, message, itemStack.getType(), itemStack.getDurability(), itemStack.getEnchantments(),
@@ -191,8 +238,7 @@ public class LocaleManager{
             translateKeys[idx] = lk;
             idx++;
         }
-        final String json = localeParser.buildTellrawJson(convertedMessage, placeholders, translateKeys);
-        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + formatName(player) + " " + json);
+        messenger.send(player, localeParser.parseSegments(convertedMessage, placeholders, translateKeys));
         return true;
     }
 
@@ -251,8 +297,7 @@ public class LocaleManager{
                 translateKeys[idx] = lk;
                 idx++;
             }
-            final String json = localeParser.buildTellrawJson(convertedMessage, placeholders, translateKeys);
-            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + formatName(player) + " " + json);
+            messenger.send(player, localeParser.parseSegments(convertedMessage, placeholders, translateKeys));
         }
         return true;
     }
@@ -275,8 +320,7 @@ public class LocaleManager{
         }
         final String convertedMessage = localeParser.convertFormattingTokens(message);
         final String key = queryEntityType(type, extra);
-        final String json = localeParser.buildTellrawJson(convertedMessage, new String[]{"<mob>"}, new String[]{key});
-        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + formatName(player) + " " + json);
+        messenger.send(player, localeParser.parseSegments(convertedMessage, new String[]{"<mob>"}, new String[]{key}));
         return true;
     }
 
@@ -539,21 +583,6 @@ public class LocaleManager{
      */
     public String toServerLocale(final String key) {
         return englishTranslations.getOrDefault(key, "<none>");
-    }
-
-    /**
-     * Format player name according to server's Bukkit version
-     *
-     * @param player Player whose name to format
-     * @return Formatted name
-     */
-    private String formatName(Player player) {
-        if (!isBelow113()) {
-            // Better Geyser/Floodgate compatibility
-            return "\"" + player.getName() + "\"";
-        } else {
-            return player.getName();
-        }
     }
 
     /**

--- a/src/main/java/me/pikamug/localelib/LocaleParser.java
+++ b/src/main/java/me/pikamug/localelib/LocaleParser.java
@@ -1,5 +1,7 @@
 package me.pikamug.localelib;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -17,7 +19,7 @@ public class LocaleParser {
      */
     public String convertFormattingTokens(final String message) {
         String result = message;
-        // Convert %#RRGGBB% to §x§R§R§G§G§B§B
+        // Convert %#RRGGBB% to \u00A7x\u00A7R\u00A7R\u00A7G\u00A7G\u00A7B\u00A7B
         final Matcher hexMatcher = hexTokenPattern.matcher(result);
         final StringBuffer hexSb = new StringBuffer();
         while (hexMatcher.find()) {
@@ -29,7 +31,7 @@ public class LocaleParser {
         }
         hexMatcher.appendTail(hexSb);
         result = hexSb.toString();
-        // Convert &#RRGGBB to §x§R§R§G§G§B§B
+        // Convert &#RRGGBB to \u00A7x\u00A7R\u00A7R\u00A7G\u00A7G\u00A7B\u00A7B
         final Matcher ampMatcher = ampHexPattern.matcher(result);
         final StringBuffer ampSb = new StringBuffer();
         while (ampMatcher.find()) {
@@ -44,19 +46,22 @@ public class LocaleParser {
     }
 
     /**
-     * Build a tellraw JSON array from a message containing section-sign formatting codes
-     * and placeholder strings. Hex colors ({@code §x§R§R§G§G§B§B}) are converted to
-     * proper JSON {@code "color":"#RRGGBB"} properties, and placeholders are converted
-     * to {@code {"translate":"key"}} components.
+     * Parse a message containing section-sign formatting codes and placeholder strings into an
+     * ordered list of {@link MessageSegment}s - either literal text runs or translatable
+     * placeholders, each carrying whatever formatting was active when it was encountered. This is
+     * the shared parsing core behind {@link #buildTellrawJson(String, String[], String[])} and the
+     * {@link ComponentMessenger} implementations, so the section-sign/hex-color/placeholder parsing
+     * logic lives in exactly one place.
      *
      * @param message the message with section-sign codes and placeholder strings
      * @param placeholders the placeholder strings to replace (e.g. {@code <item>})
      * @param translateKeys the corresponding translation keys for each placeholder
-     * @return a tellraw JSON array string
+     * @return an ordered list of parsed segments
      */
-    public String buildTellrawJson(String message, final String[] placeholders, final String[] translateKeys) {
-        final StringBuilder json = new StringBuilder("[");
-        final StringBuilder segment = new StringBuilder();
+    List<MessageSegment> parseSegments(final String message, final String[] placeholders,
+            final String[] translateKeys) {
+        final List<MessageSegment> segments = new ArrayList<>();
+        final StringBuilder text = new StringBuilder();
         int i = 0;
         String color = null;
         boolean bold = false;
@@ -64,47 +69,15 @@ public class LocaleParser {
         boolean underline = false;
         boolean strikethrough = false;
         boolean obfuscated = false;
-        boolean componentStarted = false;
         int placeholderIdx = 0;
 
         while (i < message.length()) {
             // Check for placeholder match
             if (placeholders != null && placeholderIdx < placeholders.length
                     && message.startsWith(placeholders[placeholderIdx], i)) {
-                // Flush current text segment
-                if (segment.length() > 0) {
-                    if (componentStarted) {
-                        json.append(",");
-                    }
-                    appendTextComponent(json, segment, color, bold, italic, underline, strikethrough, obfuscated);
-                    segment.setLength(0);
-                    componentStarted = true;
-                }
-                // Build translate component with inherited color
-                if (componentStarted) {
-                    json.append(",");
-                }
-                json.append("{\"translate\":\"").append(translateKeys[placeholderIdx]).append("\"");
-                if (color != null) {
-                    json.append(",\"color\":\"").append(color).append("\"");
-                }
-                if (bold) {
-                    json.append(",\"bold\":true");
-                }
-                if (italic) {
-                    json.append(",\"italic\":true");
-                }
-                if (underline) {
-                    json.append(",\"underline\":true");
-                }
-                if (strikethrough) {
-                    json.append(",\"strikethrough\":true");
-                }
-                if (obfuscated) {
-                    json.append(",\"obfuscated\":true");
-                }
-                json.append("}");
-                componentStarted = true;
+                flushText(segments, text, color, bold, italic, underline, strikethrough, obfuscated);
+                segments.add(new MessageSegment(true, translateKeys[placeholderIdx], color, bold, italic,
+                        underline, strikethrough, obfuscated));
                 i += placeholders[placeholderIdx].length();
                 placeholderIdx++;
                 continue;
@@ -114,7 +87,7 @@ public class LocaleParser {
                 final char code = Character.toLowerCase(message.charAt(i + 1));
 
                 if (code == 'x' && i + 13 < message.length()) {
-                    // Try to parse hex color: §x§R§R§G§G§B§B
+                    // Try to parse hex color: \u00A7x\u00A7R\u00A7R\u00A7G\u00A7G\u00A7B\u00A7B
                     boolean validHex = true;
                     for (int j = 2; j <= 13; j += 2) {
                         if (message.charAt(i + j) != '\u00A7') {
@@ -128,36 +101,21 @@ public class LocaleParser {
                         }
                     }
                     if (validHex) {
-                        // Flush current segment before color change
-                        if (segment.length() > 0) {
-                            if (componentStarted) {
-                                json.append(",");
-                            }
-                            appendTextComponent(json, segment, color, bold, italic, underline, strikethrough, obfuscated);
-                            segment.setLength(0);
-                            componentStarted = true;
-                        }
+                        flushText(segments, text, color, bold, italic, underline, strikethrough, obfuscated);
                         // Extract hex color
                         final StringBuilder hex = new StringBuilder("#");
                         for (int j = 0; j < 6; j++) {
                             hex.append(Character.toLowerCase(message.charAt(i + 3 + j * 2)));
                         }
                         color = hex.toString();
-                        i += 14; // Skip §x§R§R§G§G§B§B
+                        i += 14; // Skip \u00A7x\u00A7R\u00A7R\u00A7G\u00A7G\u00A7B\u00A7B
                     } else {
-                        segment.append(message.charAt(i));
+                        text.append(message.charAt(i));
                         i++;
                     }
                 } else if ((code >= '0' && code <= '9') || (code >= 'a' && code <= 'f')) {
                     // Standard color code: flush and update color
-                    if (segment.length() > 0) {
-                        if (componentStarted) {
-                            json.append(",");
-                        }
-                        appendTextComponent(json, segment, color, bold, italic, underline, strikethrough, obfuscated);
-                        segment.setLength(0);
-                        componentStarted = true;
-                    }
+                    flushText(segments, text, color, bold, italic, underline, strikethrough, obfuscated);
                     color = getMinecraftColorName(code);
                     i += 2;
                 } else if (code == 'l') {
@@ -177,14 +135,7 @@ public class LocaleParser {
                     i += 2;
                 } else if (code == 'r') {
                     // Reset: flush and clear all formatting
-                    if (segment.length() > 0) {
-                        if (componentStarted) {
-                            json.append(",");
-                        }
-                        appendTextComponent(json, segment, color, bold, italic, underline, strikethrough, obfuscated);
-                        segment.setLength(0);
-                        componentStarted = true;
-                    }
+                    flushText(segments, text, color, bold, italic, underline, strikethrough, obfuscated);
                     color = null;
                     bold = false;
                     italic = false;
@@ -193,56 +144,91 @@ public class LocaleParser {
                     obfuscated = false;
                     i += 2;
                 } else {
-                    segment.append(message.charAt(i));
+                    text.append(message.charAt(i));
                     i++;
                 }
             } else {
-                segment.append(message.charAt(i));
+                text.append(message.charAt(i));
                 i++;
             }
         }
 
-        // Flush remaining segment
-        if (segment.length() > 0) {
-            if (componentStarted) {
+        // Flush remaining text
+        flushText(segments, text, color, bold, italic, underline, strikethrough, obfuscated);
+        return segments;
+    }
+
+    /**
+     * Append the buffered text as a new segment (if non-empty) and clear the buffer.
+     */
+    private void flushText(final List<MessageSegment> segments, final StringBuilder text, final String color,
+            final boolean bold, final boolean italic, final boolean underline, final boolean strikethrough,
+            final boolean obfuscated) {
+        if (text.length() > 0) {
+            segments.add(new MessageSegment(false, text.toString(), color, bold, italic, underline,
+                    strikethrough, obfuscated));
+            text.setLength(0);
+        }
+    }
+
+    /**
+     * Build a tellraw JSON array from a message containing section-sign formatting codes
+     * and placeholder strings. Hex colors ({@code \u00A7x\u00A7R\u00A7R\u00A7G\u00A7G\u00A7B\u00A7B}) are converted to
+     * proper JSON {@code "color":"#RRGGBB"} properties, and placeholders are converted
+     * to {@code {"translate":"key"}} components.
+     *
+     * @param message the message with section-sign codes and placeholder strings
+     * @param placeholders the placeholder strings to replace (e.g. {@code <item>})
+     * @param translateKeys the corresponding translation keys for each placeholder
+     * @return a tellraw JSON array string
+     */
+    public String buildTellrawJson(final String message, final String[] placeholders, final String[] translateKeys) {
+        return segmentsToJson(parseSegments(message, placeholders, translateKeys));
+    }
+
+    private String segmentsToJson(final List<MessageSegment> segments) {
+        final StringBuilder json = new StringBuilder("[");
+        for (int i = 0; i < segments.size(); i++) {
+            if (i > 0) {
                 json.append(",");
             }
-            appendTextComponent(json, segment, color, bold, italic, underline, strikethrough, obfuscated);
+            appendSegmentJson(json, segments.get(i));
         }
-
         json.append("]");
         return json.toString();
     }
 
     /**
-     * Append a JSON text component to the builder for the given text segment.
+     * Append a JSON component for the given segment.
      */
-    private void appendTextComponent(final StringBuilder json, final StringBuilder text,
-            final String color, final boolean bold, final boolean italic,
-            final boolean underline, final boolean strikethrough, final boolean obfuscated) {
-        final String escaped = text.toString()
-                .replace("\\", "\\\\")
-                .replace("\"", "\\\"")
-                .replace("\n", "\\n")
-                .replace("\t", "\\t")
-                .replace("\r", "\\r");
-        json.append("{\"text\":\"").append(escaped).append("\"");
-        if (color != null) {
-            json.append(",\"color\":\"").append(color).append("\"");
+    private void appendSegmentJson(final StringBuilder json, final MessageSegment segment) {
+        if (segment.isTranslatable()) {
+            json.append("{\"translate\":\"").append(segment.getContent()).append("\"");
+        } else {
+            final String escaped = segment.getContent()
+                    .replace("\\", "\\\\")
+                    .replace("\"", "\\\"")
+                    .replace("\n", "\\n")
+                    .replace("\t", "\\t")
+                    .replace("\r", "\\r");
+            json.append("{\"text\":\"").append(escaped).append("\"");
         }
-        if (bold) {
+        if (segment.getColor() != null) {
+            json.append(",\"color\":\"").append(segment.getColor()).append("\"");
+        }
+        if (segment.isBold()) {
             json.append(",\"bold\":true");
         }
-        if (italic) {
+        if (segment.isItalic()) {
             json.append(",\"italic\":true");
         }
-        if (underline) {
+        if (segment.isUnderline()) {
             json.append(",\"underline\":true");
         }
-        if (strikethrough) {
+        if (segment.isStrikethrough()) {
             json.append(",\"strikethrough\":true");
         }
-        if (obfuscated) {
+        if (segment.isObfuscated()) {
             json.append(",\"obfuscated\":true");
         }
         json.append("}");

--- a/src/main/java/me/pikamug/localelib/MessageSegment.java
+++ b/src/main/java/me/pikamug/localelib/MessageSegment.java
@@ -1,0 +1,75 @@
+package me.pikamug.localelib;
+
+/**
+ * Immutable description of one formatted segment of a parsed message: either literal text, or a
+ * placeholder that should be rendered as a client-side translated component. Produced by
+ * {@link LocaleParser#parseSegments(String, String[], String[])} and consumed by
+ * {@link ComponentMessenger} implementations. Package-private: this is an internal building block,
+ * not part of the library's public API.
+ */
+final class MessageSegment {
+    private final boolean translatable;
+    private final String content;
+    private final String color;
+    private final boolean bold;
+    private final boolean italic;
+    private final boolean underline;
+    private final boolean strikethrough;
+    private final boolean obfuscated;
+
+    MessageSegment(final boolean translatable, final String content, final String color,
+            final boolean bold, final boolean italic, final boolean underline,
+            final boolean strikethrough, final boolean obfuscated) {
+        this.translatable = translatable;
+        this.content = content;
+        this.color = color;
+        this.bold = bold;
+        this.italic = italic;
+        this.underline = underline;
+        this.strikethrough = strikethrough;
+        this.obfuscated = obfuscated;
+    }
+
+    /**
+     * @return true if {@link #getContent()} is a translation key to render as a translatable
+     * component, false if it is literal text to render as-is.
+     */
+    boolean isTranslatable() {
+        return translatable;
+    }
+
+    /**
+     * @return the literal text, or the translation key, depending on {@link #isTranslatable()}.
+     */
+    String getContent() {
+        return content;
+    }
+
+    /**
+     * @return the color for this segment: a Minecraft color name (e.g. {@code "red"}) or a hex
+     * string (e.g. {@code "#ff0000"}), or null if no color applies.
+     */
+    String getColor() {
+        return color;
+    }
+
+    boolean isBold() {
+        return bold;
+    }
+
+    boolean isItalic() {
+        return italic;
+    }
+
+    boolean isUnderline() {
+        return underline;
+    }
+
+    boolean isStrikethrough() {
+        return strikethrough;
+    }
+
+    boolean isObfuscated() {
+        return obfuscated;
+    }
+}


### PR DESCRIPTION
## Problem

Messages were sent by hand-building a tellraw JSON string and dispatching
it as a console command (`tellraw <player> <json>`). This works but goes
through the command dispatcher for every message, and produces legacy-style
components even on servers that support richer, modern chat APIs.

## Fix

Messages are now sent as real chat components directly to the player,
with the underlying API chosen automatically at startup:

- On Paper and its forks, where the Adventure API is available, messages
  are built and sent as Adventure `Component`s.
- On plain Spigot/CraftBukkit, messages are built and sent via the
  BungeeCord Chat API (`player.spigot().sendMessage(...)`), which every
  Spigot-API-based server has bundled since 1.13.

The detection is a runtime check (does this server's `Player` class
implement Adventure's `Audience`?) with no compile-time or import-level
reference to Adventure types outside the Adventure-specific class, so
servers without Adventure on the classpath never attempt to load it.

The message-parsing logic (section-sign codes, hex colors, placeholders)
is unchanged in behavior — it was extracted into a shared `parseSegments()`
method so both the new component-based path and the existing
`buildTellrawJson()` method use the same parsing code.

## Testing

- Existing `LocaleParserTest` suite (12 tests covering tellraw JSON output)
  passes unchanged, since `buildTellrawJson()` is now a thin wrapper over
  the same parsing logic and produces byte-identical output.
- Verified by manual code review; brace/paren/bracket balance checked
  across all changed and new files.
- **Needs real-world testing before merge**, since it can't be verified
  from a build alone: please test message sending on both a Paper (or
  Paper-fork) server and a plain Spigot/Purpur server to confirm the
  correct messenger is chosen in each case and no `ClassNotFoundError`/
  `NoClassDefFoundError` occurs on the non-Paper server.